### PR TITLE
refactor: use correct past tense of bind

### DIFF
--- a/classes/TTSHandler.js
+++ b/classes/TTSHandler.js
@@ -43,7 +43,7 @@ module.exports = class TTSHandler {
 	}
 
 	/**
-	 * Sends a message to the binded text channel.
+	 * Sends a message to the bound text channel.
 	 * @param {string} data - The message to be used.
 	 * @param {Object} embedExtras - Extra data to be passed to the embed.
 	 * @param {boolean} error - Whether or not the message is an error.
@@ -65,7 +65,7 @@ module.exports = class TTSHandler {
 	}
 
 	/**
-	 * Sends a localized message to the binded text channel.
+	 * Sends a localized message to the bound text channel.
 	 * @param {string} code - The code of the locale string to be used.
 	 * @param {Object} embedExtras - Extra data to be passed to the embed.
 	 * @param {boolean} error - Whether or not the message is an error.


### PR DESCRIPTION
Closes #122

### Thank you for your interest in contributing!
Before proceeding, please review the [guidelines for contributing](https://github.com/ZapSquared/Warden/blob/master/CONTRIBUTING.md).

- [x] Are you targeting the `next` branch? (right side)
- [x] Did you review the guidelines for contributing?
- [x] Does your code pass linting checks?
- [ ] Did you document your code?
- [ ] Is this change necessary?

### Scope of change
- [ ] Major change
- [x] Minor change
- [ ] Documentation only

### Type of change
- [ ] Bug fix
- [ ] Feature
- [x] Other

### Description
Please describe the changes.

Bound is the correct past tense of bind.