### PR TITLE
refactor: rename permissions to use parenthetical plurals

### DIFF
--- a/locales/en/discord.json
+++ b/locales/en/discord.json
@@ -1,6 +1,6 @@
 {
-	"USER_MISSING_PERMISSIONS": "You are missing permissions: %1",
-	"BOT_MISSING_PERMISSIONS": "I am missing permissions: %1",
+	"USER_MISSING_PERMISSIONS": "You are missing permission(s): %1",
+	"BOT_MISSING_PERMISSIONS": "I am missing permission(s): %1",
 	"BOT_MISSING_PERMISSIONS_BASIC": "I need to be able to connect and speak in the voice channel.",
 	"CMD_ERROR": "There was an error while handling the command.",
 	"INTERACTION_WRONG_USER": "That is not your interaction.",


### PR DESCRIPTION
### Thank you for your interest in contributing!
Before proceeding, please review the [guidelines for contributing](https://github.com/ZapSquared/Warden/blob/master/CONTRIBUTING.md).

- [x] Are you targeting the `next` branch? (right side)
- [x] Did you review the guidelines for contributing?
- [x] Does your code pass linting checks?
- [ ] Did you document your code?
- [ ] Is this change necessary?

### Scope of change
- [ ] Major change
- [x] Minor change
- [ ] Documentation only

### Type of change
- [ ] Bug fix
- [ ] Feature
- [x] Other

### Description
Please describe the changes.

`permissions` should be `permission(s)` as indication that the `permission` may be a plural or a singular.
